### PR TITLE
bug fix: incorrect localedir

### DIFF
--- a/usr/bin/ice
+++ b/usr/bin/ice
@@ -39,7 +39,7 @@ _CHROMIUM_BIN = "/usr/bin/chromium-browser"
 _VIVALDI_BIN = "/usr/bin/vivaldi"
 _FIREFOX_BIN = "/usr/bin/firefox"
 
-gettext.bindtextdomain('messages', '../share/ice/locale/')
+gettext.bindtextdomain('messages', os.path.dirname(__file__)+ '/../share/ice/locale/')
 gettext.textdomain('messages')
 _ = gettext.gettext
 


### PR DESCRIPTION
I was fix localedir, sorry.

# 449e44c  commited was my developping dir, # 2431ad4 is correctry localedir (os.path.dirname(__file__)+ '/../share/ice/locale/')
  