### PR TITLE
ice-firefox: fully hide navbar and the top toolbars

### DIFF
--- a/usr/bin/ice-firefox
+++ b/usr/bin/ice-firefox
@@ -15,7 +15,7 @@ path = os.path.dirname(chromepath)
 execute = 'firefox -profile ' + path + ' -no-remote -new-instance' + ' ' + sys.argv[1]
 
 os.system('mkdir -p ' + chromepath)
-os.system('echo "#nav-bar { visibility: hidden !important; max-height: 0 !important; margin-bottom: -20px !important; } #TabsToolbar { display: none !important; }" > ' + chromepath + '/userChrome.css')
+os.system('echo "#navigator-toolbox, #titlebar { display: none !important; } #nav-bar { display: none !important; visibility: hidden !important; max-height: 0 !important; margin-bottom: -20px !important; } #TabsToolbar { display: none !important; }" > ' + chromepath + '/userChrome.css')
 os.system('echo "user_pref(\\"browser.cache.disk.enable\\", false);" > ' + profilepath + '/user.js')
 os.system('echo "user_pref(\\"browser.cache.disk.capacity\\", 0);" >> ' + profilepath + '/user.js')
 os.system('echo "user_pref(\\"browser.cache.disk.filesystem_reported\\", 1);" >> ' + profilepath + '/user.js')


### PR DESCRIPTION
On the latest Firefox Nightly, bars are not fully hidden for SSBs. This patches forces `display: none` on those toolbars which forces them to hide on SSBs.

Before: (note the half-visible little green lock and the white line on the top)
![screenshot from 2018-05-30 20-44-22](https://user-images.githubusercontent.com/4532423/40721303-b3e864b0-644b-11e8-9083-f089282beae7.jpg)

After:
![screenshot from 2018-05-30 20-55-58](https://user-images.githubusercontent.com/4532423/40721360-e18bfa08-644b-11e8-9694-0c57e8dff3c2.jpg)

