### PR TITLE
Option to isolate profiles for chromium-based browers

### DIFF
--- a/usr/bin/ice
+++ b/usr/bin/ice
@@ -200,7 +200,7 @@ def applicate():
     address = normalize(url.get_text())
 
     semiformatted = ""
-    array = filter(str.isalpha, title)
+    array = filter(str.isalnum, title)
     for obj in array:
         semiformatted = semiformatted + obj
     formatted = semiformatted.lower()
@@ -245,16 +245,13 @@ def writefile(title, formatted, address, iconext, location):
     elif vivaldi.get_active() == True:
         browser = "vivaldi"
     elif firefox.get_active() == True:
-        browser = "ice-firefox"
+        browser = "firefox"
     else:
         print(_("ERROR: An unknown browser selection error has occurred."))
         sys.exit(1)
 
     with open(appfile, 'w') as appfile1:
         appfile1.truncate()
-        address1 = str.replace(address, 'http://', '')
-        address2 = str.replace(address1, 'https://', '')
-        address3 = str.replace(address2, '/', '_')
 
         appfile1.write("[Desktop Entry]\n")
         appfile1.write("Version=1.0\n")
@@ -267,9 +264,12 @@ def writefile(title, formatted, address, iconext, location):
             profile_path_argument = " --user-data-dir={0}/profiles/{1}".format(_ICE_DIR, formatted)
             appfile1.write("X-ICE-SSB-Profile={0}\n".format(formatted))
 
-        if (browser == "ice-firefox"):
-            appfile1.write("Exec={0} {1} ICE-SSB-{2}\n".format(browser, address, formatted))
-            appfile1.write("IceFirefox={0}\n".format(address3))
+        if (browser == "firefox"):
+            firefox_profile_path	= "{0}/firefox".format(_ICE_DIR)
+            firefox_profile	= formatted
+            appfile1.write("Exec={0} --profile {3}/{4} --no-remote --class ICE-SSB-{2} {1}\n".format(browser, address, formatted, firefox_profile_path, firefox_profile))
+            appfile1.write("IceFirefox={0}\n".format(firefox_profile))
+            init_firefox_profile("{0}/{1}".format(firefox_profile_path, firefox_profile))
         else:
             appfile1.write("Exec={0} --app={1} --class=ICE-SSB-{2}{3}\n".format(browser, address, formatted, profile_path_argument))
 
@@ -290,6 +290,32 @@ def writefile(title, formatted, address, iconext, location):
     iconline, pixbuf = get_details(appfile)
     liststore.prepend([pixbuf, iconline])
 
+def init_firefox_profile(path):
+    chromepath = "{0}/chrome".format(path)
+    settingsfile = "{0}/user.js".format(path)
+    cssfile = "{0}/userChrome.css".format(chromepath)
+
+    os.system('mkdir -p ' + chromepath)
+    os.system('cp -n /usr/lib/peppermint/ice/search.json.mozlz4 ' + path + '/search.json.mozlz4')
+    os.system("touch {0}".format(cssfile))
+    with open(cssfile, 'w') as cfile:
+        cfile.write("#nav-bar { visibility: hidden !important; max-height: 0 !important; margin-bottom: -20px !important; } #identity-box, #navigator-toolbox::after, #TabsToolbar { display: none !important; }")
+
+    os.system("touch {0}".format(settingsfile))
+    with open(settingsfile, 'w') as sfile:
+        sfile.write('user_pref("browser.cache.disk.enable", false);')
+        sfile.write('user_pref("browser.cache.disk.capacity", 0);')
+        sfile.write('user_pref("browser.cache.disk.filesystem_reported", 1);')
+        sfile.write('user_pref("browser.cache.disk.smart_size.enabled", false);')
+        sfile.write('user_pref("browser.cache.disk.smart_size.first_run", false);')
+        sfile.write('user_pref("browser.cache.disk.smart_size.use_old_max", false);')
+        sfile.write('user_pref("browser.ctrlTab.previews", true);')
+        sfile.write('user_pref("browser.tabs.warnOnClose", false);')
+        sfile.write('user_pref("plugin.state.flash", 2);')
+
+    # rhein: do we really need this? 
+    #os.system('rm -rf ' + chromepath + '/cache2')
+
 
 def delete(button):
     a = iconview.get_selected_items()
@@ -298,7 +324,7 @@ def delete(button):
     liststore.remove(b)
 
     semiformatted = ""
-    array = filter(str.isalpha, c)
+    array = filter(str.isalnum, c)
 
     for obj in array:
         semiformatted = semiformatted + obj
@@ -314,10 +340,7 @@ def delete(button):
         if "IceFirefox=" in line:
             profile = str.replace(line, 'IceFirefox=', '')
             directory = os.path.expanduser('{0}/firefox'.format(_ICE_DIR))
-
-            for profiles in os.listdir(directory):
-#                if profile in profiles:## edited by MG ##
-                    os.system("rm -rf {0}/{1}".format(directory, profile))
+            os.system("rm -rf {0}/{1}".format(directory, profile))
 
         if "X-ICE-SSB-Profile=" in line:
             profile = str.replace(line, 'X-ICE-SSB-Profile=', '')
@@ -659,7 +682,7 @@ class Ice(Gtk.Window):
         global isolate_profile
         isolate_profile=False
         isolate_box = Gtk.VBox()
-        isolate_button = Gtk.CheckButton(label="Isolate Sessions into separate browser profile")
+        isolate_button = Gtk.CheckButton(label="Isolate Sessions into separate browser profile (Note: Firefox Sessions are always isolated by default)")
         isolate_button.connect("toggled", self.isolate_clicked)
         isolate_box.add(isolate_button)
 

--- a/usr/bin/ice
+++ b/usr/bin/ice
@@ -200,7 +200,7 @@ def applicate():
     address = normalize(url.get_text())
 
     semiformatted = ""
-    array = filter(str.isalnum, title)
+    array = filter(str.isalpha, title)
     for obj in array:
         semiformatted = semiformatted + obj
     formatted = semiformatted.lower()
@@ -251,6 +251,7 @@ def writefile(title, formatted, address, iconext, location):
         sys.exit(1)
 
     with open(appfile, 'w') as appfile1:
+        global isolate_profile
         appfile1.truncate()
 
         appfile1.write("[Desktop Entry]\n")
@@ -258,20 +259,18 @@ def writefile(title, formatted, address, iconext, location):
         appfile1.write("Name={0}\n".format(title))
         appfile1.write("Comment={0} (Ice SSB)\n".format(title))
 
-        global isolate_profile
-        profile_path_argument = ""
-        if isolate_profile == True:
-            profile_path_argument = " --user-data-dir={0}/profiles/{1}".format(_ICE_DIR, formatted)
-            appfile1.write("X-ICE-SSB-Profile={0}\n".format(formatted))
-
         if (browser == "firefox"):
-            firefox_profile_path	= "{0}/firefox".format(_ICE_DIR)
-            firefox_profile	= formatted
-            appfile1.write("Exec={0} --profile {3}/{4} --no-remote --class ICE-SSB-{2} {1}\n".format(browser, address, formatted, firefox_profile_path, firefox_profile))
-            appfile1.write("IceFirefox={0}\n".format(firefox_profile))
-            init_firefox_profile("{0}/{1}".format(firefox_profile_path, firefox_profile))
+            firefox_profile_path  = "{0}/firefox/{1}".format(_ICE_DIR, formatted)
+            appfile1.write("Exec={0} --class ICE-SSB-{2} --profile {3} --no-remote {1}\n".format(browser, address, formatted, firefox_profile_path))
+            appfile1.write("IceFirefox={0}\n".format(formatted))
+            init_firefox_profile(firefox_profile_path)
         else:
-            appfile1.write("Exec={0} --app={1} --class=ICE-SSB-{2}{3}\n".format(browser, address, formatted, profile_path_argument))
+            if isolate_profile == True:
+                profile_path = "{0}/profiles/{1}".format(_ICE_DIR, formatted)
+                appfile1.write("Exec={0} --app={1} --class=ICE-SSB-{2} --user-data-dir={3}\n".format(browser, address, formatted, profile_path))
+                appfile1.write("X-ICE-SSB-Profile={0}\n".format(formatted))
+            else:
+              appfile1.write("Exec={0} --app={1} --class=ICE-SSB-{2}\n".format(browser, address, formatted))
 
         appfile1.write("Terminal=false\n")
         appfile1.write("X-MultipleArgs=false\n")
@@ -324,7 +323,7 @@ def delete(button):
     liststore.remove(b)
 
     semiformatted = ""
-    array = filter(str.isalnum, c)
+    array = filter(str.isalpha, c)
 
     for obj in array:
         semiformatted = semiformatted + obj
@@ -349,6 +348,22 @@ def delete(button):
 
     os.system("rm {0}".format(appfile))
 
+
+def clean_orphaned_profiles(known_names):
+    known_profiles = []
+    for kn in known_names: 
+        semiformatted = ""
+        array = filter(str.isalpha, kn)
+        for obj in array:
+            semiformatted = semiformatted + obj
+        known_profiles.append(semiformatted.lower())
+
+    for p_type in ['profiles','firefox']:
+        for fl in os.listdir("{0}/{1}/".format(_ICE_DIR, p_type)):
+            a = "{0}/{1}/{2}".format(_ICE_DIR, p_type, fl)
+            if not os.path.isdir(a) or fl not in known_profiles:
+                #os.system("rm -rf {0}".format(a))
+                print("Would run: rm -rf {0}".format(a))
 
 class IconSel(Gtk.FileChooserDialog):
 
@@ -590,7 +605,7 @@ class Ice(Gtk.Window):
 
         where_store = [_("Accessories"), _("Games"), _("Graphics"), _("Internet"),
                        _("Office"), _("Programming"), _("Sound & Video"), _("System Tools")]
-        where_lab = Gtk.Label(_("Where in the menu?"))
+        where_lab = Gtk.Label(label="Where in the menu?")
         global where
         where = Gtk.ComboBoxText()
         where.set_entry_text_column(0)
@@ -616,9 +631,9 @@ class Ice(Gtk.Window):
         icon_box.pack_start(icon, False, False, 10)
         icon_box.pack_start(icon_void, False, False, 10)
 
-        choose_icon = Gtk.Button(_("Select an icon"))
+        choose_icon = Gtk.Button(label="Select an icon")
         choose_icon.connect("clicked", self.icon_select)
-        download_icon = Gtk.Button(_("Use site favicon"))
+        download_icon = Gtk.Button(label="Use site favicon")
         download_icon.connect("clicked", self.icon_download)
 
         icon_vbox = Gtk.VBox()
@@ -711,13 +726,14 @@ class Ice(Gtk.Window):
 
         create_hbox = Gtk.HBox()
         create_hbox.pack_start(create_vbox, True, True, 20)
-        create_lab = Gtk.Label(_("Create"))
+        create_lab = Gtk.Label(label="Create")
 
         ######################
         #   'Remove' page.   #
         ######################
 
         global liststore
+        known_profiles = []
         liststore = Gtk.ListStore(Pixbuf, str)
 
         for fl in os.listdir(_APPS_DIR):
@@ -726,6 +742,9 @@ class Ice(Gtk.Window):
                 nameline, pixbuf = get_details(a)
                 if nameline is not None and pixbuf is not None:
                     liststore.append([pixbuf, nameline])
+                    known_profiles.append(nameline)
+
+        clean_orphaned_profiles(known_profiles)
 
         global iconview
         iconview = Gtk.IconView()
@@ -753,7 +772,7 @@ class Ice(Gtk.Window):
 
         remove_hbox = Gtk.HBox()
         remove_hbox.pack_start(remove_vbox, True, True, 20)
-        remove_lab = Gtk.Label(_("Remove"))
+        remove_lab = Gtk.Label(label="Remove")
 
         ##########################
         #   Main window stuff.   #

--- a/usr/bin/ice
+++ b/usr/bin/ice
@@ -380,8 +380,8 @@ def clean_orphaned_profiles(known_apps):
         for fl in os.listdir("{0}/{1}/".format(_ICE_DIR, p_type)):
             a = "{0}/{1}/{2}".format(_ICE_DIR, p_type, fl)
             if not os.path.isdir(a) or fl not in known_profiles:
-                #os.system("rm -rf {0}".format(a))
-                print("Would run: rm -rf {0}".format(a))
+                os.system("rm -rf {0}".format(a))
+
 
 class IconSel(Gtk.FileChooserDialog):
 

--- a/usr/bin/ice
+++ b/usr/bin/ice
@@ -64,7 +64,10 @@ def get_details(app):
     a = open(app, 'r')
     nameline = ""
     iconline = ""
-    is_ice = False
+    profile = ""
+    is_ice	= False
+    is_firefox = False
+    is_isolated = False
 
     for line in a:
         if "Name=" in line:
@@ -86,11 +89,24 @@ def get_details(app):
             is_ice = True
         elif "StartupWMClass=ICE-SSB" in line:
             is_ice = True
+        elif "IceFirefox=" in line:
+            is_firefox = True
+            profile = str.replace(line, 'IceFirefox=', '').strip()
+        elif "X-ICE-SSB-Profile=" in line:
+            is_isolated = True
+            profile = str.replace(line, 'X-ICE-SSB-Profile=', '').strip()
 
-    if nameline is not None and iconline is not None and is_ice is True:
-        return (nameline, pixbuf)
+    if nameline != "" and iconline != "" and is_ice is True:
+        details = {
+          'nameline' : nameline,
+          'profile' : profile,
+          'is_firefox' : is_firefox,
+          'is_isolated' : is_isolated,
+          'pixbuf': pixbuf
+          }
+        return details
 
-    return (None, None)
+    return None
 
 
 def normalize(url):
@@ -286,8 +302,9 @@ def writefile(title, formatted, address, iconext, location):
     iconpath = _ICE_ICON
     new_icon = Pixbuf.new_from_file_at_size(iconpath, 32, 32)
     icon.set_from_pixbuf(new_icon)
-    iconline, pixbuf = get_details(appfile)
-    liststore.prepend([pixbuf, iconline])
+    details = get_details(appfile)
+    if details is not None:
+        liststore.prepend([ details['pixbuf'], details['nameline'] ])
 
 def init_firefox_profile(path):
     chromepath = "{0}/chrome".format(path)
@@ -349,14 +366,15 @@ def delete(button):
     os.system("rm {0}".format(appfile))
 
 
-def clean_orphaned_profiles(known_names):
+def clean_orphaned_profiles(known_apps):
     known_profiles = []
-    for kn in known_names: 
-        semiformatted = ""
-        array = filter(str.isalpha, kn)
-        for obj in array:
-            semiformatted = semiformatted + obj
-        known_profiles.append(semiformatted.lower())
+    for app in known_apps:
+        a = "{0}/firefox/{1}".format(_ICE_DIR, app['profile'])
+        if app['profile'] != "":
+            # make sure firefox apps have profiles available
+            if app['is_firefox'] is True and not os.path.isdir(a):
+                init_firefox_profile(a)
+            known_profiles.append(app['profile'])
 
     for p_type in ['profiles','firefox']:
         for fl in os.listdir("{0}/{1}/".format(_ICE_DIR, p_type)):
@@ -739,10 +757,10 @@ class Ice(Gtk.Window):
         for fl in os.listdir(_APPS_DIR):
             a = "{0}/{1}".format(_APPS_DIR, fl)
             if not os.path.isdir(a):
-                nameline, pixbuf = get_details(a)
-                if nameline is not None and pixbuf is not None:
-                    liststore.append([pixbuf, nameline])
-                    known_profiles.append(nameline)
+                details = get_details(a)
+                if details is not None:
+                    liststore.append([ details['pixbuf'], details['nameline'] ])
+                    known_profiles.append(details)
 
         clean_orphaned_profiles(known_profiles)
 

--- a/usr/bin/ice
+++ b/usr/bin/ice
@@ -54,9 +54,8 @@ if not os.path.exists(_APPS_DIR):
     os.system("mkdir -p {0}".format(_APPS_DIR))
 
 headers = {
-    'User-Agent': 'Mozilla/5.0 (Macintosh; Intel Mac OS X 10_9_2) \
-        AppleWebKit/537.36 (KHTML, like Gecko) Chrome/33.0.1750.152 \
-        Safari/537.36'
+    'User-Agent': 'Mozilla/5.0 (Windows NT 6.1; WOW64; rv:64.0) Gecko/20100101 Firefox/64.0',
+    #'User-Agent': 'Mozilla/5.0 (Macintosh; Intel Mac OS X 10_9_2) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/33.0.1750.152 Safari/537.36'
 }
 
 
@@ -160,13 +159,12 @@ def download_favicon(url, file_prefix='', target_dir='/tmp'):
     return sanitized_filename
 
 
-def parse_markup_for_favicon(markup, url):
-    parsed_site_uri = urlparse(url)
+def parse_markup_for_favicon(markup, parsed_site_uri):
 
-#    soup = BeautifulSoup(markup)
-    soup = BeautifulSoup(markup, "lxml") ## edited by MG ##
+    soup = BeautifulSoup(markup, "lxml")
 
     icon_link = soup.find('link', rel='icon')
+
     if icon_link and icon_link.has_attr('href'):
 
         favicon_url = icon_link['href']
@@ -197,7 +195,7 @@ def get_favicon_url(url):
         raise Exception(_("Unable to find URL. Is it valid? {0}").format(url))
 
     if response.status_code == requests.codes.ok:
-        favicon_url = parse_markup_for_favicon(response.content, url)
+        favicon_url = parse_markup_for_favicon(response.content, parsed_site_uri)
 
         if favicon_url:
             return favicon_url

--- a/usr/bin/ice
+++ b/usr/bin/ice
@@ -82,6 +82,9 @@ def get_details(app):
             except:
                 pixbuf = Pixbuf.new_from_file_at_size(_ICE_ICON, 16, 16)
         elif "StartupWMClass=Chromium" in line:
+            # for legacy apps
+            is_ice = True
+        elif "StartupWMClass=ICE-SSB" in line:
             is_ice = True
 
     if nameline is not None and iconline is not None and is_ice is True:
@@ -249,30 +252,35 @@ def writefile(title, formatted, address, iconext, location):
 
     with open(appfile, 'w') as appfile1:
         appfile1.truncate()
+        address1 = str.replace(address, 'http://', '')
+        address2 = str.replace(address1, 'https://', '')
+        address3 = str.replace(address2, '/', '_')
+
         appfile1.write("[Desktop Entry]\n")
         appfile1.write("Version=1.0\n")
         appfile1.write("Name={0}\n".format(title))
         appfile1.write("Comment={0} (Ice SSB)\n".format(title))
 
+        global isolate_profile
+        profile_path_argument = ""
+        if isolate_profile == True:
+            profile_path_argument = " --user-data-dir={0}/profiles/{1}".format(_ICE_DIR, formatted)
+            appfile1.write("X-ICE-SSB-Profile={0}\n".format(formatted))
+
         if (browser == "ice-firefox"):
-            appfile1.write("Exec={0} {1}\n".format(browser, address))
+            appfile1.write("Exec={0} {1} ICE-SSB-{2}\n".format(browser, address, formatted))
+            appfile1.write("IceFirefox={0}\n".format(address3))
         else:
-            appfile1.write("Exec={0} --app={1}\n".format(browser, address))
+            appfile1.write("Exec={0} --app={1} --class=ICE-SSB-{2}{3}\n".format(browser, address, formatted, profile_path_argument))
 
         appfile1.write("Terminal=false\n")
         appfile1.write("X-MultipleArgs=false\n")
         appfile1.write("Type=Application\n")
-        appfile1.write("Icon={0}/.local/share/ice/{1}.{2}\n".format(_HOME, formatted, iconext))
+        appfile1.write("Icon={0}/{1}.{2}\n".format(_ICE_DIR, formatted, iconext))
         appfile1.write("Categories=GTK;{0}\n".format(location))
         appfile1.write("MimeType=text/html;text/xml;application/xhtml_xml;\n")
-        appfile1.write("StartupWMClass=Chromium\n")
+        appfile1.write("StartupWMClass=ICE-SSB-{0}\n".format(formatted))
         appfile1.write("StartupNotify=true\n")
-
-        if (browser == "ice-firefox"):
-            address1 = str.replace(address, 'http://', '')
-            address2 = str.replace(address1, 'https://', '')
-            address3 = str.replace(address2, '/', '_')
-            appfile1.write("IceFirefox={0}".format(address3))
 
     name.set_text("")
     url.set_text("")
@@ -310,6 +318,11 @@ def delete(button):
             for profiles in os.listdir(directory):
 #                if profile in profiles:## edited by MG ##
                     os.system("rm -rf {0}/{1}".format(directory, profile))
+
+        if "X-ICE-SSB-Profile=" in line:
+            profile = str.replace(line, 'X-ICE-SSB-Profile=', '')
+            directory = os.path.expanduser('{0}/profiles'.format(_ICE_DIR))
+            os.system("rm -rf {0}/{1}".format(directory, profile))
 
     os.system("rm {0}".format(appfile))
 
@@ -527,6 +540,12 @@ class Ice(Gtk.Window):
             new_icon = Pixbuf.new_from_file_at_size(iconpath, 32, 32)
             icon.set_from_pixbuf(new_icon)
 
+    def isolate_clicked(self, button):
+        global isolate_profile
+        isolate_profile=False
+        if button.get_active() == True:
+          isolate_profile = True
+
     def __init__(self):
         Gtk.Window.__init__(self, title="Ice")
         self.current_directory = os.path.realpath(_APPS_DIR)
@@ -637,6 +656,13 @@ class Ice(Gtk.Window):
                 os.path.exists(_CHROMIUM_BIN):
             chromium.set_active(True)
 
+        global isolate_profile
+        isolate_profile=False
+        isolate_box = Gtk.VBox()
+        isolate_button = Gtk.CheckButton(label="Isolate Sessions into separate browser profile")
+        isolate_button.connect("toggled", self.isolate_clicked)
+        isolate_box.add(isolate_button)
+
         apply_button = Gtk.Button.new_from_stock(Gtk.STOCK_APPLY)
         apply_button.connect("clicked", self.apply_clicked)
         close_button = Gtk.Button.new_from_stock(Gtk.STOCK_CLOSE)
@@ -657,6 +683,7 @@ class Ice(Gtk.Window):
         create_vbox.pack_start(url, False, False, 10)
         create_vbox.pack_start(where_box, False, False, 10)
         create_vbox.pack_start(icon_hbox, False, False, 10)
+        create_vbox.pack_start(isolate_box, False, False, 10)
         create_vbox.pack_start(button_box, False, False, 0)
 
         create_hbox = Gtk.HBox()

--- a/usr/bin/ice-firefox
+++ b/usr/bin/ice-firefox
@@ -12,11 +12,7 @@ profilepath = os.path.expanduser('~/.local/share/ice/firefox/' + str(profileid))
 chromepath = os.path.expanduser('~/.local/share/ice/firefox/' + str(profileid) + '/chrome')
 path = os.path.dirname(chromepath)
 
-if len(sys.argv)>2:
-    execute = 'firefox --profile {0} --no-remote --new-instance --class {2} {1}'.format(path, sys.argv[1], sys.argv[2])
-else:
-    execute = 'firefox --profile {0} --no-remote --new-instance {1}'.format(path, sys.argv[1])
-print(execute)
+execute = 'firefox -profile ' + path + ' -no-remote -new-instance' + ' ' + sys.argv[1]
 
 os.system('mkdir -p ' + chromepath)
 os.system('echo "#nav-bar { visibility: hidden !important; max-height: 0 !important; margin-bottom: -20px !important; } #identity-box, #navigator-toolbox::after, #TabsToolbar { display: none !important; }" > ' + chromepath + '/userChrome.css')

--- a/usr/bin/ice-firefox
+++ b/usr/bin/ice-firefox
@@ -12,7 +12,11 @@ profilepath = os.path.expanduser('~/.local/share/ice/firefox/' + str(profileid))
 chromepath = os.path.expanduser('~/.local/share/ice/firefox/' + str(profileid) + '/chrome')
 path = os.path.dirname(chromepath)
 
-execute = 'firefox -profile ' + path + ' -no-remote -new-instance' + ' ' + sys.argv[1]
+if len(sys.argv)>2:
+    execute = 'firefox --profile {0} --no-remote --new-instance --class {2} {1}'.format(path, sys.argv[1], sys.argv[2])
+else:
+    execute = 'firefox --profile {0} --no-remote --new-instance {1}'.format(path, sys.argv[1])
+print(execute)
 
 os.system('mkdir -p ' + chromepath)
 os.system('echo "#nav-bar { visibility: hidden !important; max-height: 0 !important; margin-bottom: -20px !important; } #identity-box, #navigator-toolbox::after, #TabsToolbar { display: none !important; }" > ' + chromepath + '/userChrome.css')


### PR DESCRIPTION
Changes integrated:

1. Use a unique WMClass for each App ("ICE-SSB-" & sanitized app name)
2. New Option (UI: Checkbox) to request isolated instances

This is useful e.g. for running a G-Mail instance separate from normal browsing etc.
Also, using separate instances is apparently the only way to make SSB-Apps have their own Icon in KDE (see Issue #16 )
