### PR TITLE
[WIP] Favicon downloader: Try to get og:image first

### DIFF
--- a/usr/bin/ice
+++ b/usr/bin/ice
@@ -563,12 +563,22 @@ class Ice(Gtk.Window):
         if self.page is not None:
             self.soup = bs4.BeautifulSoup(self.page.read(), "html.parser")
 
-            for iconformat in self.iconformats:
-                self.icon_link = self.soup.find("link", {"rel": iconformat})
-                if self.icon_link is not None:
+            og_image = self.soup.find("meta", {"property": "og:image"})
+            if og_image is not None:
+                og_image = og_image["content"]
+                if ("://") in og_image:
+                    self.icon_link = og_image
+                else:
                     self.icon_link = (self.parsed_uri.scheme + "://" +
                                       self.parsed_uri.netloc +
-                                      self.icon_link["href"])
+                                      og_image["content"])
+            else:
+                for iconformat in self.iconformats:
+                    self.icon_link = self.soup.find("link", {"rel": iconformat})
+                    if self.icon_link is not None:
+                        self.icon_link = (self.parsed_uri.scheme + "://" +
+                                          self.parsed_uri.netloc +
+                                          self.icon_link["href"])
 
             if self.icon_link is None:
                 self.iconrequest = requests.get(


### PR DESCRIPTION
Some websites provide really small favicons.

Facebook for instance provides a 16x16px favicon which looks really blurry when
used on the desktop (Alt-tab, dock etc..).

It might be possible to fake the user agent and define the screen resolution
within the request to force such websites to give better resolutions (when asked
via Firefox directly, Facebook gives 32x32px for instance).

In any case, if the website supports og:image, we should try and use that. This
gives us a nice high-res icon (325x325px in the face of Facebook).